### PR TITLE
(require 'cl-indent) -> (load-library "cl-indent")

### DIFF
--- a/noflet.el
+++ b/noflet.el
@@ -29,7 +29,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
-(require 'cl-indent)
+(load-library "cl-indent")
 
 (defun noflet|base ()
   "A base function."


### PR DESCRIPTION
Fixes #10 
