### PR TITLE
Fix unused variable warnings in noflet

### DIFF
--- a/noflet.el
+++ b/noflet.el
@@ -71,6 +71,7 @@ name."
                           (cl-function
                            (lambda ,args
                              (let ((this-fn ,saved-func-namev))
+                               (ignore this-fn)
                                ,@body)))))))))
        (fresets
         (cl-loop
@@ -99,6 +100,7 @@ name."
                      (condition-case err
                          (symbol-function (quote ,name))
                        (void-function
+                        (ignore err)
                         (symbol-function (quote noflet|base)))))))))))
     `(let ,lets
        (unwind-protect


### PR DESCRIPTION
When using the noflet macro, there are unused variable warnings for 'err' and
'this-fn'.  These can be smothered by adding a call to ignore which will be
optimized away by the byte compiler and thus incurs no performance penalty.